### PR TITLE
Add API methods for HTTP operations

### DIFF
--- a/My_sol2/Nunit2/ApiMethods.cs
+++ b/My_sol2/Nunit2/ApiMethods.cs
@@ -1,0 +1,45 @@
+using RestSharp;
+using System.Threading.Tasks;
+
+public class ApiMethods
+{
+    private RestClient _client;
+
+    public ApiMethods(string baseUrl)
+    {
+        _client = new RestClient(baseUrl);
+    }
+
+    public async Task<RestResponse> Get(string resource)
+    {
+        var request = new RestRequest(resource, Method.Get);
+        return await _client.ExecuteAsync(request);
+    }
+
+    public async Task<RestResponse> Post(string resource, object body)
+    {
+        var request = new RestRequest(resource, Method.Post);
+        request.AddJsonBody(body);
+        return await _client.ExecuteAsync(request);
+    }
+
+    public async Task<RestResponse> Put(string resource, object body)
+    {
+        var request = new RestRequest(resource, Method.Put);
+        request.AddJsonBody(body);
+        return await _client.ExecuteAsync(request);
+    }
+
+    public async Task<RestResponse> Patch(string resource, object body)
+    {
+        var request = new RestRequest(resource, Method.Patch);
+        request.AddJsonBody(body);
+        return await _client.ExecuteAsync(request);
+    }
+
+    public async Task<RestResponse> Delete(string resource)
+    {
+        var request = new RestRequest(resource, Method.Delete);
+        return await _client.ExecuteAsync(request);
+    }
+}


### PR DESCRIPTION
This pull request adds a new class ApiMethods that provides generic methods for HTTP operations including GET, POST, PUT, PATCH, and DELETE using RestSharp. This will help in performing API testing effectively.