### PR TITLE
Execution.cs Implementation

### DIFF
--- a/My_sol2/Nunit2/Execution.cs
+++ b/My_sol2/Nunit2/Execution.cs
@@ -1,0 +1,128 @@
+using NUnit.Framework;
+using RestSharp;
+using System;
+
+namespace TestAutomation
+{
+    [TestFixture]
+    public class Execution
+    {
+        // Test case for TC-001
+        [Test]
+        public void TC_001_AddPet_ValidData()
+        {
+            // Arrange
+            var client = new RestClient("https://api.example.com/pets");
+            var request = new RestRequest(Method.POST);
+            request.AddJsonBody(new { Name = "Buddy", Age = 3, Status = "Available" });
+
+            // Act
+            var response = client.Execute(request);
+
+            // Assert
+            Assert.AreEqual(200, (int)response.StatusCode);
+        }
+
+        // Test case for TC-002
+        [Test]
+        public void TC_002_AddPet_NoName()
+        {
+            // Arrange
+            var client = new RestClient("https://api.example.com/pets");
+            var request = new RestRequest(Method.POST);
+            request.AddJsonBody(new { Age = 3, Status = "Available" });
+
+            // Act
+            var response = client.Execute(request);
+
+            // Assert
+            Assert.AreEqual(400, (int)response.StatusCode);
+        }
+
+        // Test case for TC-003
+        [Test]
+        public void TC_003_AddPet_InvalidAge()
+        {
+            // Arrange
+            var client = new RestClient("https://api.example.com/pets");
+            var request = new RestRequest(Method.POST);
+            request.AddJsonBody(new { Name = "Buddy", Age = -1, Status = "Available" });
+
+            // Act
+            var response = client.Execute(request);
+
+            // Assert
+            Assert.AreEqual(400, (int)response.StatusCode);
+        }
+
+        // Test case for TC-004
+        [Test]
+        public void TC_004_AddPet_InvalidStatus()
+        {
+            // Arrange
+            var client = new RestClient("https://api.example.com/pets");
+            var request = new RestRequest(Method.POST);
+            request.AddJsonBody(new { Name = "Buddy", Age = 3, Status = "InvalidStatus" });
+
+            // Act
+            var response = client.Execute(request);
+
+            // Assert
+            Assert.AreEqual(400, (int)response.StatusCode);
+        }
+
+        // Test case for TC-005
+        [Test]
+        public void TC_005_AddPet_OptionalFields()
+        {
+            // Arrange
+            var client = new RestClient("https://api.example.com/pets");
+            var request = new RestRequest(Method.POST);
+            request.AddJsonBody(new { Name = "Buddy", Age = 3, Status = "Available", Tags = new string[] { } });
+
+            // Act
+            var response = client.Execute(request);
+
+            // Assert
+            Assert.AreEqual(200, (int)response.StatusCode);
+        }
+
+        // Test case for TC-006
+        [Test]
+        public void TC_006_AddPet_LongName()
+        {
+            // Arrange
+            var client = new RestClient("https://api.example.com/pets");
+            var request = new RestRequest(Method.POST);
+            request.AddJsonBody(new { Name = new string('A', 256), Age = 3, Status = "Available" });
+
+            // Act
+            var response = client.Execute(request);
+
+            // Assert
+            Assert.AreEqual(200, (int)response.StatusCode);
+        }
+
+        // Test case for TC-007
+        [Test]
+        public void TC_007_AddPet_SpecialCharactersInName()
+        {
+            // Arrange
+            var client = new RestClient("https://api.example.com/pets");
+            var request = new RestRequest(Method.POST);
+            request.AddJsonBody(new { Name = "B@ddy!", Age = 3, Status = "Available" });
+
+            // Act
+            var response = client.Execute(request);
+
+            // Assert
+            Assert.AreEqual(200, (int)response.StatusCode);
+        }
+
+        // Test case for TC-008
+        [Test]
+        public void TC_008_AddPet_NullTags()
+        {
+            // Arrange
+            var client = new RestClient("https://api.example.com/pets");
+            var request = new RestRequest(Method.POST

--- a/My_sol2/Nunit2/Execution.cs
+++ b/My_sol2/Nunit2/Execution.cs
@@ -125,4 +125,44 @@ namespace TestAutomation
         {
             // Arrange
             var client = new RestClient("https://api.example.com/pets");
-            var request = new RestRequest(Method.POST
+            var request = new RestRequest(Method.POST);
+            request.AddJsonBody(new { Name = "Buddy", Age = 3, Status = "Available", Tags = null });
+
+            // Act
+            var response = client.Execute(request);
+
+            // Assert
+            Assert.AreEqual(200, (int)response.StatusCode);
+        }
+
+        // Test case for TC-009
+        [Test]
+        public void TC_009_AddPet_InvalidCategoryId()
+        {
+            // Arrange
+            var client = new RestClient("https://api.example.com/pets");
+            var request = new RestRequest(Method.POST);
+            request.AddJsonBody(new { Name = "Buddy", Age = 3, Status = "Available", CategoryId = -1 });
+
+            // Act
+            var response = client.Execute(request);
+
+            // Assert
+            Assert.AreEqual(400, (int)response.StatusCode);
+        }
+
+        // Test case for TC-010
+        [Test]
+        public void TC_010_AddPet_NegativeAge()
+        {
+            // Arrange
+            var client = new RestClient("https://api.example.com/pets");
+            var request = new RestRequest(Method.POST);
+            request.AddJsonBody(new { Name = "Buddy", Age = -1, Status = "Available" });
+
+            // Act
+            var response = client.Execute(request);
+
+            // Assert
+            Assert.AreEqual(400, (int)response.StatusCode);
+        }


### PR DESCRIPTION
Implemented NUnit tests for the following test cases from JIRA ticket AE-1:
- TC-001: Verify that a pet can be added with valid data.
- TC-002: Verify that a pet cannot be added without a name.
- TC-003: Verify that a pet cannot be added with invalid age.
- TC-004: Verify that a pet cannot be added with invalid status.
- TC-005: Verify that a pet can be added with optional fields.
- TC-006: Verify that a pet can be added with a very long name.
- TC-007: Verify that a pet can be added with special characters in the name.
- TC-008: Verify that a pet can be added with a null tag list.
- TC-009: Verify that a pet cannot be added with an invalid category ID.
- TC-010: Verify that a pet cannot be added with a negative age.

This pull request contains the implementation of NUnit tests for the above cases using RestSharp for HTTP requests.